### PR TITLE
Make userTimelock <= 7 days

### DIFF
--- a/contracts/LaunchEvent.sol
+++ b/contracts/LaunchEvent.sol
@@ -83,30 +83,41 @@ contract LaunchEvent is Ownable {
 
     uint256 private tokenReserve;
 
-    event IssuingTokenDeposited(address indexed token, uint amount);
+    event IssuingTokenDeposited(address indexed token, uint256 amount);
 
-    event UserParticipated(address indexed user, uint avaxAmount, uint rJoeAmount);
+    event UserParticipated(
+        address indexed user,
+        uint256 avaxAmount,
+        uint256 rJoeAmount
+    );
 
-    event UserWithdrawn(address indexed user, uint avaxAmount);
+    event UserWithdrawn(address indexed user, uint256 avaxAmount);
 
     event LiquidityPoolCreated(
         address indexed pair,
         address indexed token0,
         address indexed token1,
-        uint amount0,
-        uint amount1
+        uint256 amount0,
+        uint256 amount1
     );
 
-    event UserLiquidityWithdrawn(address indexed user, address indexed pair, uint amount);
+    event UserLiquidityWithdrawn(
+        address indexed user,
+        address indexed pair,
+        uint256 amount
+    );
 
-    event IssuerLiquidityWithdrawn(address indexed issuer, address indexed pair, uint amount);
+    event IssuerLiquidityWithdrawn(
+        address indexed issuer,
+        address indexed pair,
+        uint256 amount
+    );
 
     event Stopped();
 
-    event AvaxEmergencyWithdraw(address indexed user, uint amount);
+    event AvaxEmergencyWithdraw(address indexed user, uint256 amount);
 
-    event TokenEmergencyWithdraw(address indexed user, uint amount);
-
+    event TokenEmergencyWithdraw(address indexed user, uint256 amount);
 
     /// @notice Receive AVAX from the WAVAX contract
     /// @dev Needed for withdrawing from WAVAX contract
@@ -229,7 +240,7 @@ contract LaunchEvent is Ownable {
             "LaunchEvent: max allocation less than min"
         );
         require(
-            _userTimelock < 7 days,
+            _userTimelock <= 7 days,
             "LaunchEvent: can't lock user LP for more than 7 days"
         );
         require(
@@ -459,7 +470,9 @@ contract LaunchEvent is Ownable {
         if (timeElapsed < 1 days) {
             return 0;
         } else if (timeElapsed < PHASE_ONE_DURATION) {
-            return (timeElapsed - 1 days) * maxWithdrawPenalty / uint256(PHASE_ONE_DURATION - 1 days);
+            return
+                ((timeElapsed - 1 days) * maxWithdrawPenalty) /
+                uint256(PHASE_ONE_DURATION - 1 days);
         }
         return fixedWithdrawPenalty;
     }

--- a/test/LaunchEvent.test.js
+++ b/test/LaunchEvent.test.js
@@ -239,7 +239,7 @@ describe("Launch event contract initialisation", function () {
         4e11,
         5000,
         10000,
-        60 * 60 * 24 * 7 - 1,
+        60 * 60 * 24 * 7,
         60 * 60 * 24 * 8
       );
     });

--- a/test/LaunchEventPhaseOne.test.js
+++ b/test/LaunchEventPhaseOne.test.js
@@ -88,7 +88,7 @@ describe("Launch event contract phase one", function () {
       4e11, // Fixed withdraw penalty
       5000, // min allocation
       ethers.utils.parseEther("5.0"), // max allocation
-      60 * 60 * 24 * 7 - 1, // User timelock
+      60 * 60 * 24 * 7, // User timelock
       60 * 60 * 24 * 8 // Issuer timelock
     );
 

--- a/test/LaunchEventPhaseThree.test.js
+++ b/test/LaunchEventPhaseThree.test.js
@@ -81,7 +81,7 @@ describe("Launch event contract phase three", function () {
       4e11, // Fixed withdraw penalty
       5000, // min allocation
       ethers.utils.parseEther("5.0"), // max allocation
-      60 * 60 * 24 * 7 - 1, // User timelock
+      60 * 60 * 24 * 7, // User timelock
       ISSUER_TIMELOCK // Issuer timelock
     );
 

--- a/test/LaunchEventPhaseTwo.test.js
+++ b/test/LaunchEventPhaseTwo.test.js
@@ -84,7 +84,7 @@ describe("Launch event contract phase two", function () {
       4e11, // Fixed withdraw penalty
       5000, // min allocation
       ethers.utils.parseEther("5.0"), // max allocation
-      60 * 60 * 24 * 7 - 1, // User timelock
+      60 * 60 * 24 * 7, // User timelock
       60 * 60 * 24 * 8 // Issuer timelock
     );
 


### PR DESCRIPTION
Previously launch events had a requirement of `userTimelock < 7 days`. 

This causes some clunky input for `userTimelock` when creating a launch event. If caller wants to set user timelock to 7 days, he will have to input `60 * 60 * 24 * 7 - 1` instead of `60 * 60 * 24 * 7`.

Note: LaunchEvent.sol was also auto-formatted with prettier