### PR TITLE
Two input validations that would break business logic

### DIFF
--- a/contracts/LaunchEvent.sol
+++ b/contracts/LaunchEvent.sol
@@ -254,7 +254,6 @@ contract LaunchEvent {
             _issuer != address(0),
             "LaunchEvent: issuer must be address zero"
         );
-        require(_floorPrice > 0, "LaunchEvent: floor price must not be zero");
         require(
             _maxAllocation > 0,
             "LaunchEvent: max allocation must not be zero"


### PR DESCRIPTION
The modifiers are extracted to an internal view to save on contract size (which we are now at the limits).