### PR TITLE
Handle zero avaxAllocated in getIncentives

### DIFF
--- a/contracts/LaunchEvent.sol
+++ b/contracts/LaunchEvent.sol
@@ -599,6 +599,7 @@ contract LaunchEvent {
             if (address(pair) == address(0)) return tokenIncentiveIssuerRefund;
             return tokenIncentiveIssuerRefund + tokenReserve;
         } else {
+            if (avaxAllocated == 0) return 0;
             return (user.balance * tokenIncentivesForUsers) / avaxAllocated;
         }
     }


### PR DESCRIPTION
If you call `getIncentives` when `avaxAllocated == 0`, the call just reverts b/c of division by zero. This PR adds handling for that case