### PR TITLE
Fix fixedWithdrawPenalty in LaunchEvent test

### DIFF
--- a/test/LaunchEvent.test.js
+++ b/test/LaunchEvent.test.js
@@ -62,7 +62,7 @@ describe("launch event contract initialisation", function () {
       _tokenIncentivesPercent: ethers.utils.parseEther("0.05"),
       _floorPrice: 1,
       _withdrawPenaltyGradient: 2893517,
-      _fixedWithdrawPenalty: 4e17,
+      _fixedWithdrawPenalty: ethers.utils.parseEther("0.4"),
       _maxAllocation: 100,
       _userTimelock: 60 * 60 * 24 * 7,
       _issuerTimelock: 60 * 60 * 24 * 8,


### PR DESCRIPTION
`fixedWithdrawPenalty` is in parts per 1e18 and should be 40% so we want to use `ethers.utils.parseEther("0.4")` rather than 4e11.