### PR TITLE
Validation for `setPenaltyCollector`

### DIFF
--- a/contracts/RocketJoeFactory.sol
+++ b/contracts/RocketJoeFactory.sol
@@ -190,6 +190,10 @@ contract RocketJoeFactory is
         override
         onlyOwner
     {
+        require(
+            _penaltyCollector != address(0),
+            "RJFactory: penalty collector can't be address zero"
+        );
         penaltyCollector = _penaltyCollector;
         emit SetPenaltyCollector(_penaltyCollector);
     }


### PR DESCRIPTION
> The contract contains a section of code which lacks proper
validation. This could cause errors in case unexpected inputs are
provided.