### PR TITLE
Add check for wavax in launch event init

### DIFF
--- a/contracts/LaunchEvent.sol
+++ b/contracts/LaunchEvent.sol
@@ -228,6 +228,10 @@ contract LaunchEvent {
         uint256 _issuerTimelock
     ) external atPhase(Phase.NotStarted) {
         require(!initialized, "LaunchEvent: already initialized");
+        require(
+            _token != rocketJoeFactory.wavax(),
+            "LaunchEvent: token is wavax"
+        );
 
         rocketJoeFactory = IRocketJoeFactory(msg.sender);
         WAVAX = IWAVAX(rocketJoeFactory.wavax());

--- a/test/LaunchEvent.test.js
+++ b/test/LaunchEvent.test.js
@@ -194,7 +194,7 @@ describe("launch event contract initialisation", function () {
     it("should revert if token is wavax", async function () {
       const args = {
         ...this.validParams,
-        _token: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+        _token: this.wavax.address,
       };
       await testReverts(
         this.RocketFactory,


### PR DESCRIPTION
I couldn't add a test for this specific case as launch event is always initialized by the factory. I still think prudent to add this (and probably all validation to the initialization function) to decouple from the caller.