### PR TITLE
Add avaxAllocated and tokenAllocated to LaunchEventLens

### DIFF
--- a/contracts/LaunchEvent.sol
+++ b/contracts/LaunchEvent.sol
@@ -99,7 +99,10 @@ contract LaunchEvent {
 
     /// @dev The total amount of avax that was sent to the router to create the initial liquidity pair.
     /// Used to calculate the amount of LP to send based on the user's participation in the launch event
-    uint256 private avaxAllocated;
+    uint256 public avaxAllocated;
+
+    /// @dev The total amount of tokens that was sent to the router to create the initial liquidity pair.
+    uint256 public tokenAllocated;
 
     /// @dev The exact supply of LP minted when creating the initial liquidity pair.
     uint256 private lpSupply;
@@ -405,7 +408,7 @@ contract LaunchEvent {
         );
         require(avaxReserve > 0, "LaunchEvent: no avax balance");
 
-        uint256 tokenAllocated = tokenReserve;
+        tokenAllocated = tokenReserve;
 
         // Adjust the amount of tokens sent to the pool if floor price not met
         if (

--- a/contracts/LaunchEventLens.sol
+++ b/contracts/LaunchEventLens.sol
@@ -11,6 +11,7 @@ import "./interfaces/IRocketJoeFactory.sol";
 contract LaunchEventLens {
     struct LaunchEventData {
         uint256 auctionStart;
+        uint256 avaxAllocated;
         uint256 avaxReserve;
         uint256 floorPrice;
         uint256 incentives;
@@ -23,6 +24,7 @@ contract LaunchEventLens {
         uint256 phaseOneNoFeeDuration;
         uint256 phaseTwoDuration;
         uint256 rJoePerAvax;
+        uint256 tokenAllocated;
         uint256 tokenDecimals;
         uint256 tokenIncentivesPercent;
         uint256 tokenReserve;
@@ -135,6 +137,7 @@ contract LaunchEventLens {
         return
             LaunchEventData({
                 auctionStart: _launchEvent.auctionStart(),
+                avaxAllocated: _launchEvent.avaxAllocated(),
                 avaxReserve: avaxReserve,
                 floorPrice: _launchEvent.floorPrice(),
                 incentives: 0,
@@ -147,6 +150,7 @@ contract LaunchEventLens {
                 phaseOneNoFeeDuration: _launchEvent.PHASE_ONE_NO_FEE_DURATION(),
                 phaseTwoDuration: _launchEvent.PHASE_TWO_DURATION(),
                 rJoePerAvax: _launchEvent.rJoePerAvax(),
+                tokenAllocated: _launchEvent.tokenAllocated(),
                 tokenDecimals: token.decimals(),
                 tokenIncentivesPercent: _launchEvent.tokenIncentivesPercent(),
                 tokenReserve: tokenReserve,

--- a/contracts/interfaces/ILaunchEvent.sol
+++ b/contracts/interfaces/ILaunchEvent.sol
@@ -57,6 +57,10 @@ interface ILaunchEvent {
 
     function pair() external view returns (IJoePair);
 
+    function avaxAllocated() external view returns (uint256);
+
+    function tokenAllocated() external view returns (uint256);
+
     function pairBalance(address) external view returns (uint256);
 
     function getUserInfo(address) external view returns (UserInfo memory);


### PR DESCRIPTION
Add `avaxAllocated` and `tokenAllocated` to LaunchEventLens so frontend can show this data after the LP is created. Note we can't use `avaxReserves` and `tokenReserves` b/c they get subtracted in `createPair`.