### PR TITLE
Change constants in LaunchEvent back to camelcase

### DIFF
--- a/contracts/LaunchEvent.sol
+++ b/contracts/LaunchEvent.sol
@@ -50,9 +50,9 @@ contract LaunchEvent {
     /// @notice The start time of phase 1
     uint256 public auctionStart;
 
-    uint256 public PHASE_ONE_DURATION;
-    uint256 public PHASE_ONE_NO_FEE_DURATION;
-    uint256 public PHASE_TWO_DURATION;
+    uint256 public phaseOneDuration;
+    uint256 public phaseOneNoFeeDuration;
+    uint256 public phaseTwoDuration;
 
     /// @dev Amount of tokens used as incentives for locking up LPs during phase 3,
     /// in parts per 1e18 and expressed as an additional percentage to the tokens for auction.
@@ -275,9 +275,9 @@ contract LaunchEvent {
         issuer = _issuer;
 
         auctionStart = _auctionStart;
-        PHASE_ONE_DURATION = rocketJoeFactory.phaseOneDuration();
-        PHASE_ONE_NO_FEE_DURATION = rocketJoeFactory.phaseOneNoFeeDuration();
-        PHASE_TWO_DURATION = rocketJoeFactory.phaseTwoDuration();
+        phaseOneDuration = rocketJoeFactory.phaseOneDuration();
+        phaseOneNoFeeDuration = rocketJoeFactory.phaseOneNoFeeDuration();
+        phaseTwoDuration = rocketJoeFactory.phaseTwoDuration();
 
         token = IERC20MetadataUpgradeable(_token);
         uint256 balance = token.balanceOf(address(this));
@@ -319,11 +319,10 @@ contract LaunchEvent {
     function currentPhase() public view returns (Phase) {
         if (auctionStart == 0 || block.timestamp < auctionStart) {
             return Phase.NotStarted;
-        } else if (block.timestamp < auctionStart + PHASE_ONE_DURATION) {
+        } else if (block.timestamp < auctionStart + phaseOneDuration) {
             return Phase.PhaseOne;
         } else if (
-            block.timestamp <
-            auctionStart + PHASE_ONE_DURATION + PHASE_TWO_DURATION
+            block.timestamp < auctionStart + phaseOneDuration + phaseTwoDuration
         ) {
             return Phase.PhaseTwo;
         }
@@ -576,13 +575,12 @@ contract LaunchEvent {
             return 0;
         }
         uint256 timeElapsed = block.timestamp - auctionStart;
-        if (timeElapsed < PHASE_ONE_NO_FEE_DURATION) {
+        if (timeElapsed < phaseOneNoFeeDuration) {
             return 0;
-        } else if (timeElapsed < PHASE_ONE_DURATION) {
+        } else if (timeElapsed < phaseOneDuration) {
             return
-                ((timeElapsed - PHASE_ONE_NO_FEE_DURATION) *
-                    maxWithdrawPenalty) /
-                (PHASE_ONE_DURATION - PHASE_ONE_NO_FEE_DURATION);
+                ((timeElapsed - phaseOneNoFeeDuration) * maxWithdrawPenalty) /
+                (phaseOneDuration - phaseOneNoFeeDuration);
         }
         return fixedWithdrawPenalty;
     }
@@ -643,8 +641,8 @@ contract LaunchEvent {
     /// This works becuase internal functions are not in-lined in modifiers
     function _timelockElapsed() internal view {
         uint256 phase3Start = auctionStart +
-            PHASE_ONE_DURATION +
-            PHASE_TWO_DURATION;
+            phaseOneDuration +
+            phaseTwoDuration;
         if (msg.sender == issuer) {
             require(
                 block.timestamp > phase3Start + issuerTimelock,


### PR DESCRIPTION
This is currently breaking `LaunchEventLens` which expects it to them to be camelcase. It seems like in a recent commit they were all changed to camel case but a potential merge conflict reverted it back to snake case.